### PR TITLE
Change cron default to every 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+Changed
+
+- Default cron now runs every 5 minutes rather than every hour.
+
 
 ## [1.0.0] - 2021-02-23
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM oznu/s6-alpine:3.12
 ENV \
     # Fail if cont-init scripts exit with non-zero code.
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
-    # Run on the hour by default.
-    CRON="0 * * * *" \
+    # Run every 5m by default.
+    CRON="*/5 * * * *" \
     HEALTHCHECK_ID="" \
     HEALTHCHECK_HOST="https://hc-ping.com" \
     QBT_SOLO_TAG="Solo-seed" \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ services:
 
 If you have a non-default username or password, specify the `QBT_USER` and/or `QBT_PASS` environment variables, respectively.
 
-The container will check all of your torrents every hour by default.
+The container will check all of your torrents every 5 minutes by default.
 To change when it runs, specify the `CRON` environment variable with a valid cron specifier.
 For help creating a valid cron specifier, visit [cron.help][cron].
 


### PR DESCRIPTION
This tool does not touch the filesystem and is a glorified map so it can run more frequently.

Closes #1